### PR TITLE
[feature] Add sufficient indexes to tables

### DIFF
--- a/server/prisma/migrations/20250707175403_idx/migration.sql
+++ b/server/prisma/migrations/20250707175403_idx/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserSavedCompany` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[symbol]` on the table `Company` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UserSavedCompany" DROP CONSTRAINT "UserSavedCompany_companyId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserSavedCompany" DROP CONSTRAINT "UserSavedCompany_userId_fkey";
+
+-- DropTable
+DROP TABLE "UserSavedCompany";
+
+-- CreateTable
+CREATE TABLE "Watchlist" (
+    "id" SERIAL NOT NULL,
+    "savedAt" TIMESTAMP(3),
+    "unsavedAt" TIMESTAMP(3),
+    "percentChangeThreshold" DOUBLE PRECISION NOT NULL DEFAULT 5.0,
+    "previousPrice" DOUBLE PRECISION,
+    "userId" TEXT NOT NULL,
+    "companyId" INTEGER NOT NULL,
+    "companySymbol" TEXT NOT NULL,
+
+    CONSTRAINT "Watchlist_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Watchlist_userId_companyId_idx" ON "Watchlist"("userId", "companyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Company_symbol_key" ON "Company"("symbol");
+
+-- CreateIndex
+CREATE INDEX "Company_symbol_idx" ON "Company" USING HASH ("symbol");
+
+-- CreateIndex
+CREATE INDEX "User_id_idx" ON "User" USING HASH ("id");
+
+-- AddForeignKey
+ALTER TABLE "Watchlist" ADD CONSTRAINT "Watchlist_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Watchlist" ADD CONSTRAINT "Watchlist_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,28 +20,33 @@ model User {
   username      String
   email         String
   password      String
-  savedCompanies UserSavedCompany[]
+  watchlist     Watchlist[]
+  @@index([id], type: Hash)
 }
 
 model Company {
   id            Int             @id @default(autoincrement())
-  symbol        String
+  symbol        String          @unique
   name          String
   exchange      String?
   assetType     String?
   ipoDate       String?
   delistingDate String          @default("N/A")
   status        String?
-  userSavedCompany UserSavedCompany[]
+  watchlist     Watchlist[]
+  @@index([symbol], type: Hash)
 }
 
-model UserSavedCompany {
+model Watchlist {
   id            Int     @id @default(autoincrement())
-  userId        String
-  companyId     Int
-  companySymbol String
+  savedAt       DateTime?
+  unsavedAt     DateTime?
   percentChangeThreshold Float @default(5.0)
   previousPrice Float?
-  company       Company @relation(fields: [companyId], references: [id])
+  userId        String
   user          User    @relation(fields: [userId], references: [id])
+  companyId     Int
+  companySymbol String
+  company       Company @relation(fields: [companyId], references: [id])
+  @@index([userId, companyId])
 }

--- a/server/src/routes/companies.js
+++ b/server/src/routes/companies.js
@@ -99,7 +99,7 @@ router.get("/api/companies/filter", async (req, res) => {
         contains: assetType,
         mode: "insensitive",
       };
-    }
+    } 
     if (status && status !== "all") {
       where.status = {
         contains: status,

--- a/server/src/seed.js
+++ b/server/src/seed.js
@@ -27,7 +27,7 @@ async function seeding(url) {
   rawDatasetCSV.slice(1).forEach((line) => {
     const updatedLine = line.split(",").map((s) => s.replace(/\r/g, ""));
     if (updatedLine[0] !== "") {
-      database.create(
+      database.createRecord(
         database.TABLE_NAMES_ENUM.COMPANIES,
         makeObject(headers, updatedLine),
       );

--- a/server/src/systems/notification.js
+++ b/server/src/systems/notification.js
@@ -28,7 +28,7 @@ async function percentDropMailerCallback(emailer, decodedMessage) {
   try {
     const sqlQuery = `
       SELECT DISTINCT u.email, u.id as "userId", usc."percentChangeThreshold", usc."previousPrice" FROM "User" u
-      JOIN "UserSavedCompany" usc ON u.id = usc."userId"
+      JOIN "Watchlist" usc ON u.id = usc."userId"
       WHERE usc."companyId" = ${decodedMessage.companyId}
     `;
     if (
@@ -64,7 +64,7 @@ async function percentDropMailerCallback(emailer, decodedMessage) {
         ),
       );
       await database.executeQuery(
-        `UPDATE "UserSavedCompany" SET "previousPrice" = ${decodedMessage.data.c} WHERE "companyId" = ${decodedMessage.companyId} AND "userId" = '${user.userId}'`,
+        `UPDATE "Watchlist" SET "previousPrice" = ${decodedMessage.data.c} WHERE "companyId" = ${decodedMessage.companyId} AND "userId" = '${user.userId}'`,
       );
     });
     return SUCCESS;
@@ -78,7 +78,7 @@ class StockPriceNotificationService {
     this.stageName = stageName;
     this.publisherStage = cache.redisModule.createClient();
     this.subscriberStage = cache.redisModule.createClient();
-    this.timeInterval = (30000 << 1) // 1 minute
+    this.timeInterval = (30000 << 1) 
     this.iteration = 0;
     this.emailer = new Emailer();
   }
@@ -91,7 +91,7 @@ class StockPriceNotificationService {
     await this.publisherStage.connect();
     await this.subscriberStage.connect();
     const records = await database.executeQuery(
-      `SELECT DISTINCT "companyId", "companySymbol" FROM "UserSavedCompany"`,
+      `SELECT DISTINCT "companyId", "companySymbol" FROM "Watchlist"`,
     );
     this.publishers = new PublisherQueue();
     this.publishers.batchEnqueue(
@@ -122,8 +122,9 @@ class StockPriceNotificationService {
    */
   async refreshQueue() {
     try {
+
       const currentCompanies = await database.executeQuery(
-        `SELECT DISTINCT "companyId", "companySymbol" FROM "UserSavedCompany"`,
+        `SELECT DISTINCT "companyId", "companySymbol" FROM "Watchlist"`,
       );
 
       const queueCompanyIds = this.publishers.getQueueCompanyIds();

--- a/server/src/utilities/database.js
+++ b/server/src/utilities/database.js
@@ -4,7 +4,7 @@ const prisma = new PrismaClient();
 const TABLE_NAMES_ENUM = {
   USER: "user",
   COMPANIES: "company",
-  SAVED: "userSavedCompany", // Changed to camelCase to match Prisma's naming convention
+  SAVED: "Watchlist", // Changed to camelCase to match Prisma's naming convention
 };
 
 /**


### PR DESCRIPTION
## Description
Changed Watchlist table to B-tree index on userID and companyID in support of the queries used in notification service and the other tables to use hash index ideally Watchlist table would also use hash index since the main queries involved use equality (ideal for hash-index) but hash index does not support multi-column indexing so B-tree is the best choice.



Test Plan: Querying works the same, no errors.